### PR TITLE
Add S₀ Tuning (PEFT for hybrid recurrent-attention models)

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ Please issue/pr if you have any updates :)
 
 [LOCOST: State-Space Models for Long Document Abstractive Summarization](https://arxiv.org/abs/2401.17919)
 
+[S₀ Tuning: Zero-Overhead Adaptation of Hybrid Recurrent-Attention Models](https://arxiv.org/abs/2604.01168) [[Code](https://github.com/JackYoung27/s0-tuning)]
+
 ## Graph
 
 [Graph-Mamba: Towards Long-Range Graph Sequence Modeling with Selective State Spaces](https://github.com/bowang-lab/Graph-Mamba)
@@ -96,4 +98,3 @@ Please issue/pr if you have any updates :)
 
 - [@alxndrTL](https://github.com/alxndrTL) 
 - [@GianlucaMancusi](https://github.com/GianlucaMancusi)
-


### PR DESCRIPTION
S₀ tuning optimizes one state matrix per recurrent layer while freezing all model weights. On Qwen3.5-4B: +23.6 pp on HumanEval (p < 0.001, 10 seeds), +10.8 pp over LoRA, zero inference overhead. Tested on FalconH1-7B (Mamba-2).

Paper: https://arxiv.org/abs/2604.01168
Code: https://github.com/JackYoung27/s0-tuning