### PR TITLE
Add burn-mamba reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Please issue/pr if you have any updates :)
 
 [Mamba.c: inference of Mamba models in C and CUDA](https://github.com/kroggen/mamba.c)
 
+[burn-mamba](https://github.com/swfsql/burn-mamba): Rust library for Mamba models in the [burn](https://github.com/tracel-ai/burn/) framework
+
 ## Computer Vision
 
 [DynamicVis: An Efficient and General Visual Foundation Model for Remote Sensing Image Understanding](https://github.com/KyanChen/DynamicVis)


### PR DESCRIPTION
The [burn-mamba](https://github.com/swfsql/burn-mamba) project is a Rust library that uses the [burn](https://github.com/tracel-ai/burn/) framework.  
Being upfront, there is a lot of AI used in the port, and comments/documentation should improve in the future.

It can be accessible thanks to the burn framework, where ppl can "easily" compile and run both inference and training of Mamba 1/2/3 models on many platforms (cpu/cuda/rocm/macos/wasm), albeit they are not as optimized as the official Mamba implementation.

Note: Mamba-1 still needs more love in that project (i.e. proper forward implementation).